### PR TITLE
Set peer deps to >= 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set peer dependencies of [`event-target-shim`](https://npmjs.com/package/event-target-shim) to `>= 6` in PR [#20](https://github.com/compulim/event-target-shim-es5/pull/20)
+
 ## [1.2.1] - 2021-07-13
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "jest": "^27.0.6"
   },
   "peerDependencies": {
-    "event-target-shim": "> 6"
+    "event-target-shim": ">= 6"
   }
 }


### PR DESCRIPTION
## Changelog

### Changed

- Set peer dependencies of [`event-target-shim`](https://npmjs.com/package/event-target-shim) to `>= 6` in PR [#20](https://github.com/compulim/event-target-shim-es5/pull/20)
