### PR TITLE
Use intermediate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved to [`esbuild`](https://npmjs.com/package/esbuild) from Webpack, in PR [#22](https://github.com/compulim/event-target-shim-es5/pull/22)
+- Moved to [`esbuild`](https://npmjs.com/package/esbuild) from Webpack, in PR [#22](https://github.com/compulim/event-target-shim-es5/pull/22) and [#23](https://github.com/compulim/event-target-shim-es5/pull/23)
 
 ## [1.2.2] - 2021-07-13
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "main": "lib/index.js",
   "module": "lib/esm/index.mjs",
   "scripts": {
-    "build:cjs": "esbuild ./src/index.js --bundle --format=cjs | babel --config-file ./babel.config.cjs.json --filename index.js --out-file lib/index.js",
-    "build:esm": "esbuild ./src/index.js --bundle --format=esm | babel --config-file ./babel.config.esm.json --filename index.mjs --out-file lib/esm/index.mjs",
+    "build:cjs": "esbuild ./src/index.js --bundle --format=cjs --outfile=./lib/bundle.js && babel --config-file ./babel.config.cjs.json --out-file lib/index.js ./lib/bundle.js",
+    "build:esm": "esbuild ./src/index.js --bundle --format=esm --outfile=./lib/esm/bundle.mjs && babel --config-file ./babel.config.esm.json --out-file lib/esm/index.mjs ./lib/esm/bundle.mjs",
     "postinstall": "npm run build:cjs && npm run build:esm",
     "test": "jest"
   },


### PR DESCRIPTION
## Description

Instead of using pipes, using intermediate files is better for handling errors.

When using pipe, if the `esbuild` command failed, it will still pipe to `babel` as empty. And `babel` will output an almost empty file and obscured the issue.

## Changelog

- Moved to [`esbuild`](https://npmjs.com/package/esbuild) from Webpack, in PR [#22](https://github.com/compulim/event-target-shim-es5/pull/22) and [#23](https://github.com/compulim/event-target-shim-es5/pull/23)
